### PR TITLE
V13対応

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,9 +11,7 @@
         "type": "system"
       }
   ],
-	"scripts": [
-			"/main.js"
-	],
+	"scripts": ["/main.js"],
   "styles" : [],
   "packs": [
 		{

--- a/module.json
+++ b/module.json
@@ -1,12 +1,19 @@
 {
-	"name": "CoC7ja",
+	"id": "CoC7ja",
 	"title": "新クトゥルフ日本語辞典登録",
 	"description": "新クトゥルフの日本語辞典の置き換え。このモッドを使用するには必ずモッドを適用してから言語を変更してください",
 	"version": "0.3.1",
-	"author": "Admiral Nyar",
+  "author" : "Admiral Nyar",
 	"languages": [],
-  "system": ["CoC7"],
-	"scripts": ["main.js"],
+	"systems": [
+      {
+        "id": "CoC7",
+        "type": "system"
+      }
+  ],
+	"scripts": [
+			"/main.js"
+	],
   "styles" : [],
   "packs": [
 		{
@@ -75,6 +82,6 @@
 	"manifest" : "https://raw.githubusercontent.com/AdmiralNyar/CoC7ja/master/module.json",
   "compatibility": {
     "minimum": "11",
-    "verified": "11"
+    "verified": "13"
   }
 }


### PR DESCRIPTION
Module.json内のnameキーがバージョンアップに伴い追加／名称変更されたため、そちらの対応になります。v12までは"compatibility"キーを12に変更するだけで動作していましたが、v13よりとうとうエラーメッセージが表示されるようになったため、動作確認報告を兼ねてプルリクエストさせて頂きます。

テスト環境
・本体 v13.344
・CoC7 system v7.17